### PR TITLE
feat: add optional mutation steps support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scality/react-chained-query",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A wrapper of react-query useQuery hook allowing chained queries.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/useChainedMutations.tsx
+++ b/src/useChainedMutations.tsx
@@ -469,18 +469,16 @@ export function useChainedMutations(
       ? requiredSteps.every((s) => s.status === 'success')
       : steps.some((s) => s.status === 'success')); // If all optional, at least one must succeed
 
-  const optionalFailures = useMemo(() => {
-    return steps
-      .filter((s) => s.optional && s.status === 'error')
-      .map((s) => {
-        const mutation = getMutation(s.id);
-        return {
-          id: s.id,
-          label: s.label,
-          error: mutation?.error || executionErrors[s.id] || new Error('Unknown error'),
-        };
-      });
-  }, [steps, getMutation, executionErrors]);
+  const optionalFailures = steps
+    .filter((s) => s.optional && s.status === 'error')
+    .map((s) => {
+      const mutation = getMutation(s.id);
+      return {
+        id: s.id,
+        label: s.label,
+        error: mutation?.error || executionErrors[s.id] || new Error('Unknown error'),
+      };
+    });
 
   const hasOptionalFailures = optionalFailures.length > 0;
 

--- a/src/useChainedMutations.tsx
+++ b/src/useChainedMutations.tsx
@@ -272,12 +272,14 @@ export function useChainedMutations(
 
   const retryFns = useRef<Array<{ retry: () => void }>>([]);
   const hasStarted = useRef(false);
+  const highWaterMark = useRef<number>(-1);
 
   // Reset on configuration change
   const orderKey = executionOrder.join('|');
   useEffect(() => {
     retryFns.current = [];
     hasStarted.current = false;
+    highWaterMark.current = -1;
     setExecutionErrors({});
   }, [orderKey]);
 
@@ -293,10 +295,18 @@ export function useChainedMutations(
 
     const enhancedResults = createPreviousResults(results);
 
+    // Track the highest index we've reached
+    if (index > highWaterMark.current) {
+      highWaterMark.current = index;
+    }
+
     const runMutation = () => {
       // Get config once at the beginning for all error paths
       const config = configMapRef.current.get(current.id);
       const isOptional = config?.optional ?? false;
+
+      // Check if we're retrying a step that the chain already continued past
+      const shouldContinueChain = index >= highWaterMark.current;
 
       // Clear any previous error for this step before attempting (important for retries)
       setExecutionErrors((prev) => {
@@ -312,8 +322,8 @@ export function useChainedMutations(
         console.error(`[useChainedMutations] ${error.message}`);
         setExecutionErrors((prev) => ({ ...prev, [current.id]: error }));
 
-        // If optional, continue to next step with error
-        if (isOptional) {
+        // If optional, continue to next step with error (only if we haven't passed this point)
+        if (isOptional && shouldContinueChain) {
           execute([...results, { data: undefined, id: current.id, error }]);
         }
         return;
@@ -333,8 +343,8 @@ export function useChainedMutations(
         );
         setExecutionErrors((prev) => ({ ...prev, [current.id]: resolverError }));
 
-        // If optional, continue to next step with error
-        if (isOptional) {
+        // If optional, continue to next step with error (only if we haven't passed this point)
+        if (isOptional && shouldContinueChain) {
           execute([...results, { data: undefined, id: current.id, error: resolverError }]);
         }
         return;
@@ -343,7 +353,10 @@ export function useChainedMutations(
       try {
         current.mutation.mutate(resolvedVariables, {
           onSuccess: (data: unknown) => {
-            execute([...results, { data, id: current.id }]);
+            // Only advance chain if we haven't already passed this point
+            if (shouldContinueChain) {
+              execute([...results, { data, id: current.id }]);
+            }
           },
           onError: (error: unknown) => {
             console.error(
@@ -351,8 +364,8 @@ export function useChainedMutations(
               error,
             );
 
-            // If optional, continue to next step with error in result
-            if (isOptional) {
+            // If optional, continue to next step with error (only if we haven't passed this point)
+            if (isOptional && shouldContinueChain) {
               execute([...results, { data: undefined, id: current.id, error }]);
             }
           },
@@ -368,8 +381,8 @@ export function useChainedMutations(
         );
         setExecutionErrors((prev) => ({ ...prev, [current.id]: mutateError }));
 
-        // If optional, continue to next step with error
-        if (isOptional) {
+        // If optional, continue to next step with error (only if we haven't passed this point)
+        if (isOptional && shouldContinueChain) {
           execute([...results, { data: undefined, id: current.id, error: mutateError }]);
         }
       }
@@ -492,6 +505,7 @@ export function useChainedMutations(
   const reset = useCallback(() => {
     retryFns.current = [];
     hasStarted.current = false;
+    highWaterMark.current = -1;
     setExecutionErrors({});
   }, []);
 

--- a/src/useChainedMutations.tsx
+++ b/src/useChainedMutations.tsx
@@ -294,6 +294,10 @@ export function useChainedMutations(
     const enhancedResults = createPreviousResults(results);
 
     const runMutation = () => {
+      // Get config once at the beginning for all error paths
+      const config = configMapRef.current.get(current.id);
+      const isOptional = config?.optional ?? false;
+
       // Clear any previous error for this step before attempting (important for retries)
       setExecutionErrors((prev) => {
         if (!(current.id in prev)) return prev;
@@ -307,6 +311,11 @@ export function useChainedMutations(
         const error = new Error(`Missing variables resolver for: ${current.id}`);
         console.error(`[useChainedMutations] ${error.message}`);
         setExecutionErrors((prev) => ({ ...prev, [current.id]: error }));
+
+        // If optional, continue to next step with error
+        if (isOptional) {
+          execute([...results, { data: undefined, id: current.id, error }]);
+        }
         return;
       }
 
@@ -323,13 +332,15 @@ export function useChainedMutations(
           error,
         );
         setExecutionErrors((prev) => ({ ...prev, [current.id]: resolverError }));
+
+        // If optional, continue to next step with error
+        if (isOptional) {
+          execute([...results, { data: undefined, id: current.id, error: resolverError }]);
+        }
         return;
       }
 
       try {
-        const config = configMapRef.current.get(current.id);
-        const isOptional = config?.optional ?? false;
-
         current.mutation.mutate(resolvedVariables, {
           onSuccess: (data: unknown) => {
             execute([...results, { data, id: current.id }]);
@@ -356,6 +367,11 @@ export function useChainedMutations(
           error,
         );
         setExecutionErrors((prev) => ({ ...prev, [current.id]: mutateError }));
+
+        // If optional, continue to next step with error
+        if (isOptional) {
+          execute([...results, { data: undefined, id: current.id, error: mutateError }]);
+        }
       }
     };
 

--- a/src/useChainedMutations.tsx
+++ b/src/useChainedMutations.tsx
@@ -462,11 +462,12 @@ export function useChainedMutations(
     steps.length > 0 && steps.every((s) => s.status === 'success');
   const hasError = steps.some((s) => s.status === 'error');
 
+  const requiredSteps = steps.filter((s) => !s.optional);
   const allRequiredStepsComplete =
     steps.length > 0 &&
-    steps
-      .filter((s) => !s.optional)
-      .every((s) => s.status === 'success');
+    (requiredSteps.length > 0
+      ? requiredSteps.every((s) => s.status === 'success')
+      : steps.some((s) => s.status === 'success')); // If all optional, at least one must succeed
 
   const optionalFailures = useMemo(() => {
     return steps

--- a/src/useChainedMutations.tsx
+++ b/src/useChainedMutations.tsx
@@ -24,6 +24,7 @@ export interface StaticMutationConfig {
   id: string;
   label: string;
   mutation: MutationInstance;
+  optional?: boolean;
 }
 
 /** A mutation config with a hook function (will be called via internal component) */
@@ -31,6 +32,7 @@ export interface DynamicMutationConfig {
   id: string;
   label: string;
   hook: MutationHook;
+  optional?: boolean;
 }
 
 export type MutationConfig = StaticMutationConfig | DynamicMutationConfig;
@@ -41,11 +43,13 @@ export interface StepStatus {
   step: number;
   status: 'idle' | 'pending' | 'success' | 'error';
   retry: () => void;
+  optional?: boolean;
 }
 
 export interface PreviousResult<T = unknown> {
-  data: T;
+  data: T | undefined;
   id: string;
+  error?: unknown;
 }
 
 /**
@@ -130,6 +134,9 @@ export interface ChainedMutationsResult {
   getResult: <T = unknown>(id: string) => T | undefined;
   start: () => void;
   reset: () => void;
+  allRequiredStepsComplete: boolean;
+  hasOptionalFailures: boolean;
+  optionalFailures: Array<{ id: string; label: string; error: unknown }>;
 }
 
 /**
@@ -260,6 +267,9 @@ export function useChainedMutations(
   const variablesRef = useRef(variables);
   variablesRef.current = variables;
 
+  const configMapRef = useRef(mutationConfigMap);
+  configMapRef.current = mutationConfigMap;
+
   const retryFns = useRef<Array<{ retry: () => void }>>([]);
   const hasStarted = useRef(false);
 
@@ -317,6 +327,9 @@ export function useChainedMutations(
       }
 
       try {
+        const config = configMapRef.current.get(current.id);
+        const isOptional = config?.optional ?? false;
+
         current.mutation.mutate(resolvedVariables, {
           onSuccess: (data: unknown) => {
             execute([...results, { data, id: current.id }]);
@@ -326,6 +339,11 @@ export function useChainedMutations(
               `[useChainedMutations] Mutation "${current.id}" failed:`,
               error,
             );
+
+            // If optional, continue to next step with error in result
+            if (isOptional) {
+              execute([...results, { data: undefined, id: current.id, error }]);
+            }
           },
         });
       } catch (error) {
@@ -366,7 +384,7 @@ export function useChainedMutations(
   );
 
   const steps: StepStatus[] = useMemo(() => {
-    let hasPreviousError = false;
+    let hasPreviousRequiredError = false;
     return executionOrder
       .map((id, index) => {
         const config = mutationConfigMap.get(id);
@@ -375,12 +393,16 @@ export function useChainedMutations(
         const mutation = getMutation(id);
         if (!mutation) return null;
 
+        const isOptional = config.optional ?? false;
+
         let status: StepStatus['status'] = 'idle';
         if (executionErrors[id]) {
           status = 'error';
-          hasPreviousError = true;
-        } else if (hasPreviousError) {
-          // Keep idle for steps after an error
+          if (!isOptional) {
+            hasPreviousRequiredError = true;
+          }
+        } else if (hasPreviousRequiredError) {
+          // Keep idle for steps after a required error
         } else if (
           mutation.status === 'loading' ||
           mutation.status === 'pending'
@@ -388,7 +410,9 @@ export function useChainedMutations(
           status = 'pending';
         } else if (mutation.status === 'error') {
           status = 'error';
-          hasPreviousError = true;
+          if (!isOptional) {
+            hasPreviousRequiredError = true;
+          }
         } else if (mutation.status === 'success') {
           status = 'success';
         }
@@ -399,6 +423,7 @@ export function useChainedMutations(
           step: index + 1,
           status,
           retry: getRetryFn(index),
+          ...(isOptional && { optional: true }),
         };
       })
       .filter((s): s is StepStatus => s !== null);
@@ -407,6 +432,27 @@ export function useChainedMutations(
   const isComplete =
     steps.length > 0 && steps.every((s) => s.status === 'success');
   const hasError = steps.some((s) => s.status === 'error');
+
+  const allRequiredStepsComplete =
+    steps.length > 0 &&
+    steps
+      .filter((s) => !s.optional)
+      .every((s) => s.status === 'success');
+
+  const optionalFailures = useMemo(() => {
+    return steps
+      .filter((s) => s.optional && s.status === 'error')
+      .map((s) => {
+        const mutation = getMutation(s.id);
+        return {
+          id: s.id,
+          label: s.label,
+          error: mutation?.error || executionErrors[s.id] || new Error('Unknown error'),
+        };
+      });
+  }, [steps, getMutation, executionErrors]);
+
+  const hasOptionalFailures = optionalFailures.length > 0;
 
   const getResult = useCallback(
     <T = unknown>(id: string): T | undefined => getMutation(id)?.data,
@@ -465,5 +511,8 @@ export function useChainedMutations(
     getResult,
     start,
     reset,
+    allRequiredStepsComplete,
+    hasOptionalFailures,
+    optionalFailures,
   };
 }


### PR DESCRIPTION
## Summary

Add support for optional mutation steps that can fail gracefully without blocking the mutation chain. This enables consumers to mark enhancement steps as optional while keeping critical steps required, allowing users to continue with working results even when optional steps fail.

## What's in this PR

### Type System Updates

- **`StaticMutationConfig` & `DynamicMutationConfig`**: Add `optional?: boolean` field to mark mutations as optional
- **`StepStatus`**: Add `optional?: boolean` to expose optional status in step metadata
- **`PreviousResult<T>`**: Change `data: T` → `data: T | undefined` and add `error?: unknown` to support failed optional steps in the results chain
- **`ChainedMutationsResult`**: Add three new computed properties:
  - `allRequiredStepsComplete: boolean` - True when all required steps succeed (ignores optional failures)
  - `hasOptionalFailures: boolean` - True when any optional step has failed
  - `optionalFailures: Array<{ id, label, error }>` - Metadata for failed optional steps

### Execution Logic

**Continue on optional failures**: When an optional step fails, the chain now continues to the next step by calling `execute([...results, { data: undefined, id, error }])` in the `onError` callback.

**Block only on required errors**: Changed `hasPreviousError` to `hasPreviousRequiredError` - subsequent steps only remain `idle` if a *required* step failed, not if an optional step failed.

## What's Coming Next

This library update enables the ISV wizard refactoring in `zenko-ui`:

1. **Mutation Executor** - Pass `optional` flag from platform config to library
2. **Apply Actions Component** - Dynamic button enabling, warning banners for optional failures
3. **Summary Component** - Pass `optionalFailures` metadata to platform custom renders
4. **Platform Adoption** - Veeam platform marks auto-repo creation as optional

Reference : https://docs.google.com/document/d/1Oex0aY2p9wCsitdbpGVbrxZGSLDwjWhTyfD9ObQHFgk/edit?tab=t.0
